### PR TITLE
Disable flush-after-every-object

### DIFF
--- a/src/main/java/com/nesscomputing/jackson/NessObjectMapperProvider.java
+++ b/src/main/java/com/nesscomputing/jackson/NessObjectMapperProvider.java
@@ -58,6 +58,9 @@ class NessObjectMapperProvider implements Provider<ObjectMapper>
 
         // Don't write out nulls by default -- if you really want them, you can change it with setOptions later.
         featureMap.put(SerializationFeature.WRITE_NULL_MAP_VALUES, false);
+
+        // No need to flush after every value, which cuts throughput by ~30%
+        featureMap.put(SerializationFeature.FLUSH_AFTER_WRITE_VALUE, false);
     }
 
     @Inject(optional=true)


### PR DESCRIPTION
Improves throughput by approximately 30%
